### PR TITLE
Fix order payment model naming

### DIFF
--- a/Models/Orders/OrderPayment.cs
+++ b/Models/Orders/OrderPayment.cs
@@ -2,12 +2,12 @@
 
 namespace BuyWise.Models.Orders
 {
-    public class OrderPaymnet
+    public class OrderPayment
     {
         public long Id { get; set; }
         public long OrderId { get; set; }
         public Order? Order { get; set; }
         public long PaymentMethodId { get; set; }
-        public PaymentMehod? PaymentMehod { get; set; }
+        public PaymentMehod? PaymentMethod { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- rename `OrderPaymnet.cs` to `OrderPayment.cs`
- rename class to `OrderPayment`
- fix typo in `PaymentMethod` property name

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845dc636fdc832e8642c5815487ccc2